### PR TITLE
Improve error handling and output a summary message 

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+# Helper for finishing and exiting.
+#   $0 - A summary message to be printed and exported
+#   $1 - The script exit code. Defaults to 0, will be overwritten if $fail_on_error is set to 'no'
+finish () {
+  summary="$1"
+  exit_code="$2"
+
+  # Set the summary as an output for use in future steps
+  envman add --key SNOWPLOW_MICRO_COLLECTOR_SUMMARY --value "$summary"
+
+  # Downgrade any errors if fail_on_error is turned off
+  if [ "$fail_on_error" = "no" ]
+  then
+    unset exit_code
+  fi
+
+  # Finish and exit with the appropriate code
+  echo "$summary"
+  exit "${exit_code:-0}"
+}
+
 # Reset the Snowplow collector state
 echo "Resetting the state of the collector at $collector_url..."
 result=$(curl "$collector_url/micro/reset")
@@ -9,23 +30,12 @@ echo "Response from the server: '$result'"
 total=$(jq -r '.total' <<< "$result")
 
 # Check the result and produce a summary, mark the step as failed if required
-if [[ -z $total ]] || [[ $total -gt 0 ]]
+if [[ -z "$total" ]]
 then
-  exit_code=1
-  summary="The collector failed to reset"
+  finish "Unable to retrieve status from the collector" 1
+elif [[ $total -gt 0 ]]
+then
+  finish "The collector failed to reset" 1
 else
-  summary="The collector was reset successfully"
+  finish "The collector was reset successfully" 0
 fi
-
-# Set the summary as an output for use in future steps
-envman add --key SNOWPLOW_MICRO_COLLECTOR_SUMMARY --value "$summary"
-
-# Downgrade any errors if fail_for_bad_reset is turned off
-if [ "$fail_for_bad_reset" = "no" ]
-then
-  unset exit_code
-fi
-
-# Finish and exit with the appropriate code
-echo "$summary"
-exit "${exit_code:-0}"

--- a/step.sh
+++ b/step.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Reset the Snowplow collector state
 echo "Reset the state of the collector at $collector_url..."
@@ -8,8 +7,8 @@ result=$(curl --silent "$collector_url/micro/reset")
 # Parse the results
 total=$(jq -r '.total' <<< "$result")
 
-# Check if there are any active events 
-if [[ $total -gt 0 ]]
+# Check the result and produce a summary, mark the step as failed if required
+if [[ -z $total ]] || [[ $total -gt 0 ]]
 then
   echo "The Snowplow micro failed to reset."
   exit 1

--- a/step.sh
+++ b/step.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Reset the Snowplow collector state
-echo "Reset the state of the collector at $collector_url..."
-result=$(curl --silent "$collector_url/micro/reset")
+echo "Resetting the state of the collector at $collector_url..."
+result=$(curl "$collector_url/micro/reset")
+echo "Response from the server: '$result'"
 
 # Parse the results
 total=$(jq -r '.total' <<< "$result")

--- a/step.sh
+++ b/step.sh
@@ -11,8 +11,15 @@ total=$(jq -r '.total' <<< "$result")
 # Check the result and produce a summary, mark the step as failed if required
 if [[ -z $total ]] || [[ $total -gt 0 ]]
 then
-  echo "The Snowplow micro failed to reset."
-  exit 1
+  exit_code=1
+  summary="The collector failed to reset"
 else
-  echo "Collector reset successfully"
+  summary="The collector was reset successfully"
 fi
+
+# Set the summary as an output for use in future steps
+envman add --key SNOWPLOW_MICRO_COLLECTOR_SUMMARY --value "$summary"
+
+# Finish and exit with the appropriate code
+echo "$summary"
+exit "${exit_code:-0}"

--- a/step.sh
+++ b/step.sh
@@ -37,5 +37,5 @@ elif [[ $total -gt 0 ]]
 then
   finish "The collector failed to reset" 1
 else
-  finish "The collector was reset successfully" 0
+  finish "The collector was reset, waiting for events" 0
 fi

--- a/step.sh
+++ b/step.sh
@@ -20,6 +20,12 @@ fi
 # Set the summary as an output for use in future steps
 envman add --key SNOWPLOW_MICRO_COLLECTOR_SUMMARY --value "$summary"
 
+# Downgrade any errors if fail_for_bad_reset is turned off
+if [ "$fail_for_bad_reset" = "no" ]
+then
+  unset exit_code
+fi
+
 # Finish and exit with the appropriate code
 echo "$summary"
 exit "${exit_code:-0}"

--- a/step.yml
+++ b/step.yml
@@ -68,7 +68,7 @@ inputs:
       summary: The URL to the Snowplow Micro Collector instance
       is_expand: true
       is_required: true
-  - fail_for_bad_reset: "no"
+  - fail_on_error: "no"
     opts:
       title: Fail the step if it is unable to reset the Snowplow Micro Collector instance
       value_options:

--- a/step.yml
+++ b/step.yml
@@ -68,3 +68,9 @@ inputs:
       summary: The URL to the Snowplow Micro Collector instance
       is_expand: true
       is_required: true
+
+outputs:
+  - SNOWPLOW_MICRO_COLLECTOR_SUMMARY:
+    opts:
+      title: Operation Summary
+      summary: A message that can be used to give a summary of the step

--- a/step.yml
+++ b/step.yml
@@ -68,6 +68,12 @@ inputs:
       summary: The URL to the Snowplow Micro Collector instance
       is_expand: true
       is_required: true
+  - fail_for_bad_reset: "no"
+    opts:
+      title: Fail the step if it is unable to reset the Snowplow Micro Collector instance
+      value_options:
+      - "yes"
+      - "no"
 
 outputs:
   - SNOWPLOW_MICRO_COLLECTOR_SUMMARY:


### PR DESCRIPTION
# Background 

- https://github.com/cookpad/global-data-platform/issues/676

While we are using the nightly E2E test runs to check the Snowplow collector state, we need to be careful that issues that arise when checking the collector do not interfere with the reporting of the overall E2E test run, especially now while things are under development. 

Currently, when the Check Collector step runs, if we can't reach the instance for whatever reason the experience is a less than desirable for a couple of reasons:

1. The message output in Slack is missing counts so it looks a little odd
2. The overall build on Bitrise will fail, which can be confusing for other teams

Ideally we want to be able to minimise the disruption here if possible.

# Changes

These changes go hand in hand with other changes in cookpad/bitrise-step-snowplow-micro-check-collector#4 and aim to do the following:

1. Errors when trying to reset will no longer fail the job, instead we carefully check that the JSON came back as expected and will only fail if;
2. Added a new `fail_on_error` option similarly to the check-collector step that will allow us to conditionally skip failures. 
    - While we want to skip issues now while the infrastructure matures, we'll probably enable this later on. 
3. We now set a new `SNOWPLOW_MICRO_COLLECTOR_SUMMARY` output with a description both upon success and on any kind of failure.
    - This message can be used in the Slack output.
    - It'll eventually be overwritten by the summary in cookpad/bitrise-step-snowplow-micro-check-collector#4 **if** the workflow gets that far


To test the negative user journeys, you can see this test build here: https://app.bitrise.io/build/54aa8fff-150c-4a60-9dc8-b401ffade251